### PR TITLE
Update dependencies to latest versions to fix E0557

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ repository = "https://github.com/rust-osdev/vga"
 
 [dependencies]
 bitflags = "1.2.1"
-conquer-once = { version = "0.2.1", default-features = false }
-font8x8 = { version = "0.2.5", default-features = false, features = ["unicode"] }
-spinning_top = { version = "0.2.2", features = ["nightly"] }
-x86_64 = "0.13.2"
+conquer-once = { version = "0.3.2", default-features = false }
+font8x8 = { version = "0.3.1", default-features = false, features = ["unicode"] }
+spinning_top = { version = "0.2.4", features = ["nightly"] }
+x86_64 = "0.14.2"
 
 [dependencies.num-traits]
 version = "0.2.14"


### PR DESCRIPTION
This fixes E0557 caused in Rust v. 1.53 plus.

Signed-off-by: Ethin Probst <ethindp@protonmail.com>