### PR TITLE
Access VGA memory at arbitrary address

### DIFF
--- a/src/vga.rs
+++ b/src/vga.rs
@@ -22,7 +22,7 @@ pub static VGA: Lazy<Spinlock<Vga>> = Lazy::new(|| Spinlock::new(Vga::new()));
 /// Represents the starting address of the frame buffer for
 /// various video modes.
 #[derive(Debug, Copy, Clone)]
-#[repr(u32)]
+#[repr(usize)]
 pub enum FrameBuffer {
     /// The starting address for graphics modes.
     GraphicsMode = 0xa0000,
@@ -43,9 +43,9 @@ impl From<u8> for FrameBuffer {
     }
 }
 
-impl From<FrameBuffer> for u32 {
-    fn from(value: FrameBuffer) -> u32 {
-        value as u32
+impl From<FrameBuffer> for usize {
+    fn from(value: FrameBuffer) -> usize {
+        value as usize
     }
 }
 
@@ -156,7 +156,7 @@ impl Vga {
         // Write font to plane
         self.sequencer_registers.set_plane_mask(PlaneMask::PLANE2);
 
-        let frame_buffer = u32::from(self.get_frame_buffer()) as *mut u8;
+        let frame_buffer = usize::from(self.get_frame_buffer()) as *mut u8;
 
         for character in 0..vga_font.characters {
             for row in 0..vga_font.character_height {

--- a/src/writers/mod.rs
+++ b/src/writers/mod.rs
@@ -73,7 +73,7 @@ pub trait TextWriter: Screen {
     fn get_frame_buffer(&self) -> (SpinlockGuard<Vga>, *mut ScreenCharacter) {
         let mut vga = VGA.lock();
         let frame_buffer = vga.get_frame_buffer();
-        (vga, u32::from(frame_buffer) as *mut ScreenCharacter)
+        (vga, usize::from(frame_buffer) as *mut ScreenCharacter)
     }
 
     /// Clears the screen by setting all cells to `b' '` with
@@ -201,6 +201,6 @@ pub trait GraphicsWriter<Color> {
     fn set_mode(&self);
     /// Returns the frame buffer for this vga mode.
     fn get_frame_buffer(&self) -> *mut u8 {
-        u32::from(VGA.lock().get_frame_buffer()) as *mut u8
+        usize::from(VGA.lock().get_frame_buffer()) as *mut u8
     }
 }


### PR DESCRIPTION
The purpose of this is to support user-space VGA drivers with video memory mapped at arbitrary virtual addresses. The default behavior isn't changed except that the address type is `usize` rather than `u32`.

`FrameBuffer` now stores the address (`usize`), which is calculated in `FrameBuffer::new()` by combining the video memory start address (default `0xa0000`) with an offset which depends on the video map mode.

The video memory start address can be set in the `Vga` object with the `set_memory_start` method:
```
use vga;

vga::vga::VGA.lock().set_memory_start(0xa0000);
```
