### PR TITLE
implement a draw_rect function

### DIFF
--- a/src/writers/graphics_1280x800x256.rs
+++ b/src/writers/graphics_1280x800x256.rs
@@ -1,10 +1,13 @@
-use super::{GraphicsWriter, Screen};
+use core::slice::from_raw_parts_mut;
+
+use font8x8::UnicodeFonts;
+
 use crate::colors::DEFAULT_PALETTE;
-use crate::drawing::{Bresenham, Point};
 use crate::registers::PlaneMask;
 use crate::vga::VGA;
-use core::slice::from_raw_parts_mut;
-use font8x8::UnicodeFonts;
+use crate::writers::PrimitiveDrawing;
+
+use super::{GraphicsWriter, Screen};
 
 const WIDTH: usize = 1280;
 const HEIGHT: usize = 800;
@@ -21,7 +24,7 @@ type ColorT = u32;
 /// Basic usage:
 ///
 /// ```no_run
-/// use vga::writers::{Graphics1280x800x256, GraphicsWriter};
+/// use vga::writers::{Graphics1280x800x256, GraphicsWriter, PrimitiveDrawing};
 ///
 /// let mode = Graphics1280x800x256::new();
 /// mode.set_mode();
@@ -52,12 +55,6 @@ impl GraphicsWriter<ColorT> for Graphics1280x800x256 {
             .set_plane_mask(PlaneMask::ALL_PLANES);
         unsafe {
             from_raw_parts_mut(frame_buffer, PIXEL_COUNT).fill(color);
-        }
-    }
-
-    fn draw_line(&self, start: Point<isize>, end: Point<isize>, color: ColorT) {
-        for (x, y) in Bresenham::new(start, end) {
-            self.set_pixel(x as usize, y as usize, color);
         }
     }
 
@@ -94,6 +91,8 @@ impl GraphicsWriter<ColorT> for Graphics1280x800x256 {
         vga.color_palette_registers.load_palette(&DEFAULT_PALETTE);
     }
 }
+
+impl PrimitiveDrawing<ColorT> for Graphics1280x800x256 {}
 
 impl Graphics1280x800x256 {
     /// Creates a new `Graphics1280x800x256`.

--- a/src/writers/graphics_320x200x256.rs
+++ b/src/writers/graphics_320x200x256.rs
@@ -1,7 +1,6 @@
 use super::{GraphicsWriter, Screen};
 use crate::{
     colors::DEFAULT_PALETTE,
-    drawing::{Bresenham, Point},
     vga::{VideoMode, VGA},
 };
 use font8x8::UnicodeFonts;
@@ -45,11 +44,6 @@ impl GraphicsWriter<u8> for Graphics320x200x256 {
     fn clear_screen(&self, color: u8) {
         unsafe {
             self.get_frame_buffer().write_bytes(color, Self::SIZE);
-        }
-    }
-    fn draw_line(&self, start: Point<isize>, end: Point<isize>, color: u8) {
-        for (x, y) in Bresenham::new(start, end) {
-            self.set_pixel(x as usize, y as usize, color);
         }
     }
     fn set_pixel(&self, x: usize, y: usize, color: u8) {

--- a/src/writers/graphics_320x200x256.rs
+++ b/src/writers/graphics_320x200x256.rs
@@ -1,4 +1,5 @@
 use super::{GraphicsWriter, Screen};
+use crate::writers::PrimitiveDrawing;
 use crate::{
     colors::DEFAULT_PALETTE,
     vga::{VideoMode, VGA},
@@ -17,7 +18,7 @@ const SIZE: usize = WIDTH * HEIGHT;
 ///
 /// ```no_run
 /// use vga::colors::Color16;
-/// use vga::writers::{Graphics320x200x256, GraphicsWriter};
+/// use vga::writers::{Graphics320x200x256, GraphicsWriter, PrimitiveDrawing};
 ///
 /// let mode = Graphics320x200x256::new();
 /// mode.set_mode();
@@ -30,6 +31,7 @@ const SIZE: usize = WIDTH * HEIGHT;
 /// for (offset, character) in "Hello World!".chars().enumerate() {
 ///     mode.draw_character(118 + offset * 8, 27, character, 255);
 /// }
+/// mode.draw_rect((300, 180), (320, 200), 255);
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Graphics320x200x256;
@@ -77,6 +79,8 @@ impl GraphicsWriter<u8> for Graphics320x200x256 {
         vga.color_palette_registers.load_palette(&DEFAULT_PALETTE);
     }
 }
+
+impl PrimitiveDrawing<u8> for Graphics320x200x256 {}
 
 impl Graphics320x200x256 {
     /// Creates a new `Graphics320x200x256`.

--- a/src/writers/graphics_320x240x256.rs
+++ b/src/writers/graphics_320x240x256.rs
@@ -1,7 +1,6 @@
 use super::{GraphicsWriter, Screen};
 use crate::{
     colors::DEFAULT_PALETTE,
-    drawing::{Bresenham, Point},
     registers::PlaneMask,
     vga::{VideoMode, VGA},
 };
@@ -52,11 +51,7 @@ impl GraphicsWriter<u8> for Graphics320x240x256 {
             frame_buffer.write_bytes(color, Self::SIZE);
         }
     }
-    fn draw_line(&self, start: Point<isize>, end: Point<isize>, color: u8) {
-        for (x, y) in Bresenham::new(start, end) {
-            self.set_pixel(x as usize, y as usize, color);
-        }
-    }
+
     fn set_pixel(&self, x: usize, y: usize, color: u8) {
         let frame_buffer = self.get_frame_buffer();
         unsafe {

--- a/src/writers/graphics_320x240x256.rs
+++ b/src/writers/graphics_320x240x256.rs
@@ -1,4 +1,5 @@
 use super::{GraphicsWriter, Screen};
+use crate::writers::PrimitiveDrawing;
 use crate::{
     colors::DEFAULT_PALETTE,
     registers::PlaneMask,
@@ -18,7 +19,7 @@ const SIZE: usize = (WIDTH * HEIGHT) / 4;
 ///
 /// ```no_run
 /// use vga::colors::Color16;
-/// use vga::writers::{Graphics320x240x256, GraphicsWriter};
+/// use vga::writers::{Graphics320x240x256, GraphicsWriter, PrimitiveDrawing};
 ///
 /// let mode = Graphics320x240x256::new();
 /// mode.set_mode();
@@ -31,6 +32,7 @@ const SIZE: usize = (WIDTH * HEIGHT) / 4;
 /// for (offset, character) in "Hello World!".chars().enumerate() {
 ///     mode.draw_character(118 + offset * 8, 27, character, 255);
 /// }
+/// mode.draw_rect((300, 180), (320, 240), 255);
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Graphics320x240x256;
@@ -88,6 +90,8 @@ impl GraphicsWriter<u8> for Graphics320x240x256 {
         vga.color_palette_registers.load_palette(&DEFAULT_PALETTE);
     }
 }
+
+impl PrimitiveDrawing<u8> for Graphics320x240x256 {}
 
 impl Graphics320x240x256 {
     /// Creates a new `Graphics320x240x256`.

--- a/src/writers/graphics_640x480x16.rs
+++ b/src/writers/graphics_640x480x16.rs
@@ -1,4 +1,5 @@
 use super::{GraphicsWriter, Screen};
+use crate::writers::PrimitiveDrawing;
 use crate::{
     colors::{Color16, DEFAULT_PALETTE},
     drawing::{Bresenham, Point},
@@ -52,13 +53,6 @@ impl GraphicsWriter<Color16> for Graphics640x480x16 {
         }
     }
 
-    fn draw_line(&self, start: Point<isize>, end: Point<isize>, color: Color16) {
-        self.set_write_mode_0(color);
-        for (x, y) in Bresenham::new(start, end) {
-            self._set_pixel(x as usize, y as usize, color);
-        }
-    }
-
     fn draw_character(&self, x: usize, y: usize, character: char, color: Color16) {
         self.set_write_mode_2();
         let character = match font8x8::BASIC_FONTS.get(character) {
@@ -93,6 +87,15 @@ impl GraphicsWriter<Color16> for Graphics640x480x16 {
         // Some bios mess up the palette when switching modes,
         // so explicitly set it.
         vga.color_palette_registers.load_palette(&DEFAULT_PALETTE);
+    }
+}
+
+impl PrimitiveDrawing<Color16> for Graphics640x480x16 {
+    fn draw_line(&self, start: Point<isize>, end: Point<isize>, color: Color16) {
+        self.set_write_mode_0(color);
+        for (x, y) in Bresenham::new(start, end) {
+            self._set_pixel(x as usize, y as usize, color);
+        }
     }
 }
 

--- a/src/writers/graphics_640x480x16.rs
+++ b/src/writers/graphics_640x480x16.rs
@@ -21,8 +21,8 @@ const WIDTH_IN_BYTES: usize = WIDTH / 8;
 ///
 /// ```no_run
 /// use vga::colors::Color16;
-/// use vga::writers::{Graphics640x480x16, GraphicsWriter};
-
+/// use vga::writers::{Graphics640x480x16, GraphicsWriter, PrimitiveDrawing};
+///
 /// let mode = Graphics640x480x16::new();
 /// mode.set_mode();
 /// mode.clear_screen(Color16::Black);
@@ -34,6 +34,7 @@ const WIDTH_IN_BYTES: usize = WIDTH / 8;
 /// for (offset, character) in "Hello World!".chars().enumerate() {
 ///     mode.draw_character(270 + offset * 8, 72, character, Color16::White)
 /// }
+/// mode.draw_rect((90, 70), (530, 410), Color16::Yellow);
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Graphics640x480x16;


### PR DESCRIPTION
Implements a probably efficient `draw_rect` function, as well as some refactoring to make space for more implementations such as `draw_triangle` or `draw_sphere`.